### PR TITLE
Fix from_entries with falsy values

### DIFF
--- a/jqjq.jq
+++ b/jqjq.jq
@@ -1710,7 +1710,7 @@ def from_entries:
   reduce .[] as $kv (
     {};
     .[$kv | .key // .Key // .name // .Name] =
-      ($kv | .value // .Value)
+      ($kv | if has(\"value\") then .value else .Value end)
   );
 def with_entries(f): to_entries | map(f) | from_entries;
 

--- a/jqjq.test
+++ b/jqjq.test
@@ -714,8 +714,8 @@ to_entries
 [{"key":"a","value":1},{"key":"b","value":2}]
 
 from_entries
-[{"key":"a","value":1},{"key":"b","value":2}]
-{"a":1,"b":2}
+[{"key":"a","value":1},{"Key":"b","Value":2},{"Name":"c","value":false}]
+{"a":1,"b":2,"c":false}
 
 with_entries(.key |= "_"+. | .value += 100)
 {"a":1,"b":2}


### PR DESCRIPTION
This PR improves jq compatibility of `from_entries` to support falsy values.
```sh
 $ jq -nc '[{key:"a",value:false}] | from_entries'
{"a":false}

$ ./jqjq -n '[{key:"a",value:false}] | from_entries'
{"a":null}
```