### PR TITLE
Specify bash in the jqjq entrypoint to use non-POSIX arrays

### DIFF
--- a/jqjq
+++ b/jqjq
@@ -1,22 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 # wrapper for jqjq cli entrypoint
-# shellcheck disable=SC2016,SC3030,SC3054
+# shellcheck disable=SC2016
 
 JQ="jq"
 JQJQ_PATH="$(dirname "$0")"
 ARGS=("$@")
 
-JQ_ARGS="--raw-output --null-input"
+JQ_ARGS=("--raw-output" "--null-input")
 # some arguments require to run jq in different input/output mode
 while [ "$1" != "" ]; do
     case "$1" in
       --jq) shift; JQ="$1";;
-      --run-tests) JQ_ARGS="$JQ_ARGS --raw-input --slurp";;
-      --repl) JQ_ARGS="$JQ_ARGS --raw-input --join-output";;
+      --run-tests) JQ_ARGS+=("--raw-input" "--slurp");;
+      --repl) JQ_ARGS+=("--raw-input" "--join-output");;
       --) break;;
     esac
     shift
 done
 
-# shellcheck disable=SC2086
-exec "$JQ" -L "$JQJQ_PATH" $JQ_ARGS --args 'include "jqjq"; jqjq($ARGS.positional; $ENV)' -- "${ARGS[@]}"
+exec "$JQ" -L "$JQJQ_PATH" "${JQ_ARGS[@]}" --args 'include "jqjq"; jqjq($ARGS.positional; $ENV)' -- "${ARGS[@]}"


### PR DESCRIPTION
Since arrays are not POSIX compliant, current shell script does not work on environment where `/bin/sh` is not `bash`, for example, on Ubuntu it is `dash`.
```sh
root@66139b5e5b36:/jqjq# ./jqjq -n .
./jqjq: 7: Syntax error: "(" unexpected
```
Rather than putting the efforts to making it work within the POSIX specification, it's far easy to change the shebang to `bash`. Also I propose to use array for `JQ_ARGS` to avoid spellcheck suppression comments.