### PR TITLE
Format json with `JQ_COLORS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Note that the tests are meant to be used with jq 1.7.1.
   - [x] `--help` / `-h`
   - [x] `--null-input` / `-n`
   - [ ] `--raw-input` / `-R`
-  - [ ] `--compact-output` / `-c`
+  - [x] `--compact-output` / `-c`
   - [x] `--raw-output` / `-r`
   - [x] `--raw-output0`
   - [x] `--join-output` / `-j`

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Note that the tests are meant to be used with jq 1.7.1.
   - [x] `getpath(path)` (passthrough)
   - [x] `group`, `group_by(f)`
   - [x] `gsub($regex; f)` (passthrough)
-  - [ ] `gsub($regex; f; $flags)`
+  - [x] `gsub($regex; f; $flags)` (passthrough)
   - [x] `halt_error`, `halt_error($exit_code)`
   - [x] `has($key)` (passthrough)
   - [x] `implode` (passthrough)
@@ -201,12 +201,37 @@ Note that the tests are meant to be used with jq 1.7.1.
 - [ ] `@format "string"` Format string
 - [ ] `label $out | break $out` Break out
 - [ ] `include "f"`, `import "f"` Include
+- [ ] CLI options
+  - [x] `--help` / `-h`
+  - [x] `--null-input` / `-n`
+  - [ ] `--raw-input` / `-R`
+  - [ ] `--compact-output` / `-c`
+  - [ ] `--raw-output` / `-r`
+  - [ ] `--raw-output0`
+  - [ ] `--join-output` / `-j`
+  - [x] `--slurp` / `-s`
+  - [x] `--color-output` / `-C`
+  - [x] `--monochrome-output` / `-M`
+  - [ ] `-L directory`
+  - [ ] `--arg name value`
+  - [ ] `--rawfile name filename`
+  - [x] `--run-tests`
+  - [ ] `--run-tests [filename]`
+  - [x] `--`
+  - [ ] Combined short options
+  - [ ] More...
+  - Non-standard CLI options
+    - [x] `--jq`
+    - [x] `--lex`
+    - [x] `--no-builtins`
+    - [x] `--parse`
+    - [x] `--repl`
 - [x] Run jqjq with jqjq
 - [x] Bugs
 
 ### jq's test suite
 
-```
+```sh
 $ ./jqjq --run-tests < ../jq/tests/jq.test | grep passed
 307 of 449 tests passed
 ```

--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ Note that the tests are meant to be used with jq 1.7.1.
   - [x] `--null-input` / `-n`
   - [ ] `--raw-input` / `-R`
   - [ ] `--compact-output` / `-c`
-  - [ ] `--raw-output` / `-r`
-  - [ ] `--raw-output0`
-  - [ ] `--join-output` / `-j`
+  - [x] `--raw-output` / `-r`
+  - [x] `--raw-output0`
+  - [x] `--join-output` / `-j`
   - [x] `--slurp` / `-s`
   - [x] `--color-output` / `-C`
   - [x] `--monochrome-output` / `-M`

--- a/README.md
+++ b/README.md
@@ -205,11 +205,11 @@ Note that the tests are meant to be used with jq 1.7.1.
   - [x] `--help` / `-h`
   - [x] `--null-input` / `-n`
   - [ ] `--raw-input` / `-R`
+  - [x] `--slurp` / `-s`
   - [x] `--compact-output` / `-c`
   - [x] `--raw-output` / `-r`
   - [x] `--raw-output0`
   - [x] `--join-output` / `-j`
-  - [x] `--slurp` / `-s`
   - [x] `--color-output` / `-C`
   - [x] `--monochrome-output` / `-M`
   - [ ] `-L directory`

--- a/jqjq
+++ b/jqjq
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # wrapper for jqjq cli entrypoint
 # shellcheck disable=SC2016
 
@@ -11,7 +11,7 @@ JQ_ARGS=("--join-output" "--null-input")
 while [ "$1" != "" ]; do
     case "$1" in
       --jq) shift; JQ="$1";;
-      --run-tests) JQ_ARGS+=("--raw-input" "--slurp");;
+      --run-tests) JQ_ARGS+=("--raw-input" "--slurp"); JQ_ARGS[0]="--raw-output";;
       --repl) JQ_ARGS+=("--raw-input");;
       --) break;;
     esac

--- a/jqjq
+++ b/jqjq
@@ -6,13 +6,13 @@ JQ="jq"
 JQJQ_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 ARGS=("$@")
 
-JQ_ARGS=("--raw-output" "--null-input")
+JQ_ARGS=("--join-output" "--null-input")
 # some arguments require to run jq in different input/output mode
 while [ "$1" != "" ]; do
     case "$1" in
       --jq) shift; JQ="$1";;
       --run-tests) JQ_ARGS+=("--raw-input" "--slurp");;
-      --repl) JQ_ARGS+=("--raw-input" "--join-output");;
+      --repl) JQ_ARGS+=("--raw-input");;
       --) break;;
     esac
     shift

--- a/jqjq.jq
+++ b/jqjq.jq
@@ -1462,7 +1462,6 @@ def eval_ast($query; $path; $env; undefined_func):
               # TODO: implement in jqjq?
               elif $name == "tostring/0" then [[null], tostring]
               elif $name == "tojson/0"   then [[null], _tojson]
-              elif $name == "tojson/1"   then [[null], _tojson(a0)]
               elif $name == "fromjson/0" then [[null], _fromjson]
               # TODO: make args general
               # note "null | error" is same as empty

--- a/jqjq.jq
+++ b/jqjq.jq
@@ -2490,16 +2490,14 @@ def jqjq($args; $env):
     | if $env | has("JQ_COLORS") then
         ( ($env.JQ_COLORS | split(":")[:8]) as $custom
         | if $custom | all(length <= 12 and test("^[0-9;]*$")) then
-            {colors: ($custom + $default[$custom | length:]), ok: true}
-          else
-            {colors: $default, ok: false}
+            $custom + $default[$custom | length:]
+          else "Failed to set $JQ_COLORS\n" | stderr | $default
           end
         )
-      else
-        {colors: $default, ok: true}
+      else $default
       end
     | if $env | .NO_COLOR != null and .NO_COLOR != "" then
-        .colors = null
+        null
       end
     );
 
@@ -2523,7 +2521,7 @@ def jqjq($args; $env):
         if . == "break" then empty
         else error
         end;
-    ( parse_colors($env) as {$colors}
+    ( parse_colors($env) as $colors
     | builtins_env as $builtins_env
     | _repeat_break(
         ( "> "
@@ -2643,8 +2641,7 @@ def jqjq($args; $env):
         elif $opts.slurp then [inputs]
         else inputs
         end;
-    # TODO: jq prints "Failed to set $JQ_COLORS\n" to stderr on failure
-      parse_colors($env) as {$colors}
+      parse_colors($env) as $colors
     | ( if $opts.no_builtins then {}
         else builtins_env
         end

--- a/jqjq.jq
+++ b/jqjq.jq
@@ -3,7 +3,6 @@
 # MIT License
 #
 # TODO:
-# jq bug with error undefined function (possibly https://github.com/stedolan/jq/issues/2485?)
 # ".end" lex, require whitespace/end around ident?
 # how test associativity 1|2|3?
 # add some term builder helper, _term("TermTypeArray"; {query: ...}) etc?

--- a/jqjq.jq
+++ b/jqjq.jq
@@ -1534,6 +1534,7 @@ def eval_ast($query; $path; $env; undefined_func):
               elif $name == "match/2"       then match(a0; a1) | [[null], .]
               elif $name == "test/2"        then test(a0; a1) | [[null], .]
               elif $name == "gsub/2"        then gsub(a0; a1) | [[null], .]
+              elif $name == "gsub/3"        then gsub(a0; a1; a2) | [[null], .]
               elif $name == "atan2/2"       then [[null], atan2(a0; a1)]
               elif $name == "copysign/2"    then [[null], copysign(a0; a1)]
               elif $name == "drem/2"        then [[null], drem(a0; a1)]

--- a/jqjq.jq
+++ b/jqjq.jq
@@ -2478,6 +2478,7 @@ def jqjq($args; $env):
       elif $a == "--parse"                           then {parse: true}, (.[1:] | _f)
       elif $a == "--repl"                            then {repl: true}, (.[1:] | _f)
       elif $a == "-n" or $a == "--null-input"        then {null_input: true}, (.[1:] | _f)
+      elif $a == "-s" or $a == "--slurp"             then {slurp: true}, (.[1:] | _f)
       elif $a == "-c" or $a == "--compact-output"    then {compact_output: true}, (.[1:] | _f)
       elif $a == "-r" or $a == "--raw-output"        then {raw_output: true}, (.[1:] | _f)
       elif $a == "--raw-output0"                     then {raw_output: true,
@@ -2485,7 +2486,6 @@ def jqjq($args; $env):
                                                            raw_output0: true}, (.[1:] | _f)
       elif $a == "-j" or $a == "--join-output"       then {raw_output: true,
                                                            raw_no_lf: true}, (.[1:] | _f)
-      elif $a == "-s" or $a == "--slurp"             then {slurp: true}, (.[1:] | _f)
       elif $a == "-C" or $a == "--color-output"      then {color_output: true}, (.[1:] | _f)
       elif $a == "-M" or $a == "--monochrome-output" then {monochrome_output: true}, (.[1:] | _f)
       elif $a == "--run-tests"                       then {run_tests: true}, (.[1:] | _f)
@@ -2540,11 +2540,11 @@ def jqjq($args; $env):
     , "  --repl                    REPL"
     , ""
     , "  --null-input / -n         Null input"
+    , "  --slurp / -s              Slurp inputs into an array"
     , "  --compact-output / -c     Output each object on one line"
     , "  --raw-output / -r         Output strings raw with newline"
     , "  --raw-output0             Output strings raw with NUL"
     , "  --join-output             Output strings raw"
-    , "  --slurp / -s              Slurp inputs into an array"
     , "  --color-output / -C       Force colored output"
     , "  --monochrome-output / -M  Disable colored output"
     , "  --run-tests               Run jq tests from stdin"


### PR DESCRIPTION
This PR adds support for colors via `JQ_COLORS` and enabling/disabling with `NO_COLORS`, `--color-output`/`-C`, and `--monochrome-output`/`-M`. The formatting matches jq (not gojq).

I've tested this and it has identical behavior to jq. If we want to add tests, it would need a new harness, because `--run-tests` uses value-based equality, not formatted textual equality.

I also removed the `tojson/1` intrinsic, because neither jq nor gojq define it.

If https://github.com/jqlang/jq/pull/3034 is merged, I'll update `_tojson` here to match.