### PR TITLE
Stream `tojson`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ ./jqjq '.+. | map(.+105) | implode' <<< '[1,8]'
 $ ./jqjq "eval($(jq -Rs . jqjq.jq)+.)" <<< '"eval(\"def f: 1,8; [f,f] | map(.+105) | implode\")"'
 "jqjq"
 
-# jqjq have a REPL
+# jqjq has a REPL
 $ ./jqjq --repl
 > 1,2,3 | .*2
 2
@@ -263,7 +263,7 @@ jqjq has the common lex, parse, eval design.
 
 Lexer gets a string and chews off parts from left to right producing an array of tokens `[{<name>: ...}, ...]`. Each chew is done by testing regex:s in a priority order to make sure to match longer prefixes first, ex: `+=` is matched before `+`. For a match a lambda is evaluated, usually `{<token-name>: .}`, but in some cases like for quoted strings it is a bit more complicated.
 
-The lexer also has a stack to keep track of balance of seen `(`, `)` and `\(` to properly know how to chop of a string with interpolation into tokens. e.g. is `)` a right paratheses or contuination of a string as in `"abc \(123) def"`?
+The lexer also has a stack to keep track of balance of seen `(`, `)` and `\(` to properly know how to chop of a string with interpolation into tokens. e.g. is `)` a right parenthesis or continuation of a string as in `"abc \(123) def"`?
 
 You can use `./jqjq --lex '...'` to lex and see the tokens.
 
@@ -290,8 +290,8 @@ When evaluating the AST eval function get the current AST node, path and environ
 - "," operator in jq (and gojq) is left associate but for the way jqjq parses it creates the correct parse tree when it's right associate. Don't know why.
 - Suffix with multiple `[]` outputs values in wrong order.
 - String literal using interpolation that has more than one generator outputs in wrong order. Ex: `"\(1,2) \(3,4)"`.
-- Non-associate operators like `==` should fail, ex: `1 == 2 == 3`.
-- Object are parsed differently compared to gojq. gojq has a list of pipe queries, jqjq will only have one that might be pipe op.
+- Non-associative operators like `==` should fail, ex: `1 == 2 == 3`.
+- Objects are parsed differently compared to gojq. gojq has a list of pipe queries, jqjq will only have one that might be pipe op.
 - Less "passthrough" piggyback on jq features:
   - `reduce/foreach` via recursive function? similar to `if` or `{}`-literal?
   - `try/catch` via some backtrack return value? change `[path, value]` to include an error somehow?

--- a/jqjq.jq
+++ b/jqjq.jq
@@ -1211,7 +1211,7 @@ def _tojson_stream($opts):
         else _internal_error("unknown type \($t)")
         end
       );
-    _f($newline + $indent)
+    _f($newline)
   );
 def _tojson: [_tojson_stream({})] | join("");
 

--- a/jqjq.jq
+++ b/jqjq.jq
@@ -2306,7 +2306,7 @@ def isempty(f): [limit(1; f)] == [];
 
 # Assuming the input array is sorted, bsearch/1 returns
 # the index of the target if the target is in the input array; and otherwise
-#  (-1 - ix), where ix is the insertion point that would leave the array sorted.
+# (-1 - ix), where ix is the insertion point that would leave the array sorted.
 # If the input is not sorted, bsearch will terminate but with irrelevant results.
 def bsearch($target):
   if length == 0 then -1


### PR DESCRIPTION
I have refactored `_tojson` to stream strings and reuse concatenations. It is now significantly faster, and has fully recovered from the performance regression when I added colors in https://github.com/wader/jqjq/pull/14.

Since jq is buffered by default, I saw no penalties from streaming tiny strings instead of concatenating into larger chunks like lines. There may be a sweet spot for chunk sizes that would suit `jq --unbuffered` and gojq, but I didn't benchmark it carefully like the rest.

## Benchmarks

The `.` benchmark exercises the streaming behavior and the `tojson` benchmark collects it into an array and joins it. Notice that `streamed` (`tojson`) is now on faster than `before-colors` (`tojson`), so that performance loss has been fully regained. `before-colors` (`.`) is actually deceptive, because that revision dumped using host `tojson` instead of `_tojson`. There's no good comparison for `.`, but it seems to be as expected, matching `tojson`.

- `streamed`: d6d9e4e2524baadd3322cb2d0979f76a7af5b03e (Fold newline into indent prefix, 2024-03-08), i.e., this PR
- `master`: d0fdc43b71d285198ab4b712a1c3eb7554563d7c (Make eval work in eval, 2024-03-08), i.e., `origin/master` at the time of this PR
- `master-passthrough`: d0fdc43b71d285198ab4b712a1c3eb7554563d7c (Make eval work in eval, 2024-03-08) with `_tojson` stubbed with host `tojson`
- `after-colors`: 0532d9c7e08518ca90812021da5164957b2f937b (Fix --help with --join-output, 2024-02-07), i.e., the final commit related to color support
- `before-colors`: 8a02423cabb05a4467b27738d3add579822d3d14 (Add query? shorthand for try query catch empty, 2024-01-30), i.e., the commit before I added color support

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `streamed/jqjq . < large.json` | 2.004 ± 0.132 | 1.845 | 2.222 | 1.69 ± 0.13 |
| `streamed/jqjq tojson < large.json` | 2.124 ± 0.148 | 1.957 | 2.471 | 1.80 ± 0.15 |
| `master/jqjq . < large.json` | 3.085 ± 0.152 | 2.870 | 3.364 | 2.61 ± 0.17 |
| `master/jqjq tojson < large.json` | 2.630 ± 0.052 | 2.560 | 2.702 | 2.22 ± 0.10 |
| `master-passthrough/jqjq . < large.json` | 1.436 ± 0.153 | 1.319 | 1.748 | 1.21 ± 0.14 |
| `master-passthrough/jqjq tojson < large.json` | 1.273 ± 0.041 | 1.200 | 1.337 | 1.08 ± 0.06 |
| `after-colors/jqjq . < large.json` | 2.926 ± 0.266 | 2.715 | 3.472 | 2.47 ± 0.25 |
| `after-colors/jqjq tojson < large.json` | 2.480 ± 0.045 | 2.418 | 2.569 | 2.10 ± 0.10 |
| `before-colors/jqjq . < large.json` | 1.183 ± 0.050 | 1.127 | 1.260 | 1.00 |
| `before-colors/jqjq tojson < large.json` | 2.213 ± 0.076 | 2.120 | 2.321 | 1.87 ± 0.10 |

Generated with:

```bash
#!/usr/bin/env bash
set -eEuo pipefail

mkdir bench
cd bench
git worktree add streamed           d6d9e4e2524baadd3322cb2d0979f76a7af5b03e
git worktree add master             d0fdc43b71d285198ab4b712a1c3eb7554563d7c
git worktree add master-passthrough d0fdc43b71d285198ab4b712a1c3eb7554563d7c
git worktree add after-colors       0532d9c7e08518ca90812021da5164957b2f937b
git worktree add before-colors      8a02423cabb05a4467b27738d3add579822d3d14

# Stub _tojson to replace it with host tojson
patch -p1 -d master-passthrough <<EOF
diff --git a/jqjq.jq b/jqjq.jq
index 2500cc6..f7f2c85 100644
--- a/jqjq.jq
+++ b/jqjq.jq
@@ -1220,7 +1220,8 @@ def _tojson(\$opts):
   | _f(\$o; \$o.indent * " ")
   | if type == "array" then flatten | join("") end
   );
-def _tojson: _tojson({});
+def _tojson(\$opts): tojson;
+def _tojson: tojson;

 def undefined_func_error:
   error("undefined function \(.name)");
EOF

git clone --depth=1 https://github.com/wspace/corpus
find corpus -name project.json | sort | xargs cat > large.json

hyperfine \
  -L filter .,tojson \
  -L worktree streamed,master,master-passthrough,after-colors,before-colors \
  --export-json bench.json \
  --export-markdown bench.md \
  '{worktree}/jqjq {filter} < large.json'

# cd ..
# rm -rf bench
# git worktree prune
```