### PR TITLE
Escape all shell special characters

### DIFF
--- a/jqjq.jq
+++ b/jqjq.jq
@@ -2735,9 +2735,9 @@ def parse_options:
   );
 
 def invoke_client_jqjq:
-  # instead of @sh to not always quote
+  # instead of @sh to not always quote (as per quoting rules of ${var@Q})
   def sh_escape:
-    if . == "" or test("['\" $\n\\\\()]") then
+    if . == "" or test("[^[A-Za-z0-9%+\\-./:=@_]]") then
       "'" + gsub("'"; "'\\''") + "'"
     end;
   ( . as $args


### PR DESCRIPTION
Allows only characters which don't require quoting. I realized I was thinking about only the characters used in what's conceptually a string, but there's many more. I consulted <https://stackoverflow.com/questions/15783701/which-characters-need-to-be-escaped-when-using-bash/27817504#27817504>, which derives its list from what needs escaping with `${var@Q}`.