### PR TITLE
override linguist detection for jq files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.jq linguist-language=jq


### PR DESCRIPTION
Saw your post on mastodon: https://fosstodon.org/@wader/114614039905210462

Github uses a a library called linguist for language detection, and it's possible to override how it reports files using git attributes.

https://github.com/github-linguist/linguist
https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml

So I tested this out on a fork, and it seems to work:
https://github.com/stuarthicks/jqjq

![{0FD417B7-AF08-4E19-A916-A09054DC3E70}](https://github.com/user-attachments/assets/b344f6ec-ca12-4a1f-b98c-edb9fea331d6)

So... if you want it, here's the gitattributes change!