### PR TITLE
Escape `=` for shell, implement `--binary`, and swap `$JQ`/`--jq` precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Note that the tests are meant to be used with jq 1.7.1.
   - [x] `--null-input` / `-n`
   - [ ] `--raw-input` / `-R`
   - [x] `--slurp` / `-s`
+  - [x] `--binary` / `-b`
   - [x] `--compact-output` / `-c`
   - [x] `--raw-output` / `-r`
   - [x] `--raw-output0`

--- a/jqjq.jq
+++ b/jqjq.jq
@@ -2842,7 +2842,7 @@ def construct_jqjq_command:
     end;
   ( . as $args
   | parse_options
-  | (.jq // env.JQ // "jq") as $jq
+  | (env.JQ // .jq // "jq") as $jq
   | ($jq | test("(^|[/\\\\])(gojq|jaq)[^/\\\\]*$") | not) as $host_is_jq
   | [ ($jq | sh_escape)
     , if .action == "run-tests" then "-nsRr"

--- a/jqjq.jq
+++ b/jqjq.jq
@@ -2834,7 +2834,7 @@ def parse_options:
 def construct_jqjq_command:
   # instead of @sh to not always quote (as per quoting rules of ${var@Q})
   def sh_escape:
-    if . == "" or test("[^A-Za-z0-9%+\\-./:=@_]") then
+    if . == "" or test("[^A-Za-z0-9%+\\-./:@_]") then
       "'" + gsub("'"; "'\\''") + "'"
     end;
   ( . as $args


### PR DESCRIPTION
Some small changes:
- Escape `=` for the shell. Although the resource I consulted in #23 does not consider `=` to be special, it denotes a variable definition when used in the first argument. I recently analyzed the grammar of Bourne shell from Unix V7 for another project and this was the only difference from our escaping here.
- Check `$JQ` (in addition to `--jq`) when deciding whether to forward `--unbuffered` to the host jq
- Implement `--binary` just like `--unbuffered`. It simply defers to the host jq. Only [jq supports it](https://github.com/jqlang/jq/blob/0b1ef469734f0621283a056aa1e8f2080110b493/src/main.c#L420-L427), not gojq or jaq.
- Make `--jq` take precedence over `$JQ`. In CLIs that have both an environment variable and a flag configuring the same option, usually the flag takes precedence. This enables configuring `$JQ` globally, but overriding it when desired, or separately setting jq for stage 1 (`$JQ`) and stage 2 (`--jq`).